### PR TITLE
iPad-compatibility

### DIFF
--- a/iPokeGo.xcodeproj/project.pbxproj
+++ b/iPokeGo.xcodeproj/project.pbxproj
@@ -4321,6 +4321,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.dimitri-dessus.iPokeGo";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -4333,6 +4334,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.dimitri-dessus.iPokeGo";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};

--- a/iPokeGo/Info.plist
+++ b/iPokeGo/Info.plist
@@ -41,5 +41,12 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
* Switched Devices from “iPhone” to “Universal”.  All the views resize to full-screen and scale as expected.  
	‣ Also enables using it in Slide Over or Split View.
* Made sure iPad supports all 4 orientations (including Upside Down) while iPhone supports the same 3 as before (all but Upside Down).  This is what Apple's HIG recommends.