### PR TITLE
Fix #48

### DIFF
--- a/iPokeGo/MapViewController.h
+++ b/iPokeGo/MapViewController.h
@@ -21,8 +21,6 @@
 @property(weak, nonatomic) IBOutlet UIButton *radarButton;
 @property(weak, nonatomic) IBOutlet MKMapView *mapview;
 
-@property(strong, nonatomic) NSDictionary *localization;
-
 -(IBAction)locationAction:(id)sender;
 -(IBAction)radarAction:(id)sender;
 

--- a/iPokeGo/MapViewController.h
+++ b/iPokeGo/MapViewController.h
@@ -16,9 +16,6 @@
 #import "global.h"
 
 @interface MapViewController : UIViewController <MKMapViewDelegate, CLLocationManagerDelegate>
-{
-    BOOL isMapMoved;
-}
 
 @property(weak, nonatomic) IBOutlet UIButton *locationButton;
 @property(weak, nonatomic) IBOutlet UIButton *radarButton;

--- a/iPokeGo/MapViewController.m
+++ b/iPokeGo/MapViewController.m
@@ -39,7 +39,6 @@
 {
     if (self = [super initWithCoder:aDecoder]) {
         [self loadLocalization];
-        isMapMoved = NO;
     }
     return self;
 }
@@ -360,10 +359,11 @@
 - (void)mapView:(MKMapView *)theMapView didUpdateUserLocation:(MKUserLocation *)userLocation
 {
     //Prevents follow the user's position after the first update
-    if(!isMapMoved) {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
         [self.mapview setCenterCoordinate:userLocation.location.coordinate animated:YES];
-        isMapMoved = YES;
-    }
+
+    });
 }
 
 #pragma mark - FRC Delegate

--- a/iPokeGo/MapViewController.m
+++ b/iPokeGo/MapViewController.m
@@ -30,6 +30,7 @@
 
 @property CLLocationManager *locationManager;
 @property NSArray *animatedPokestopLured;
+@property NSDictionary *localization;
 
 @end
 

--- a/iPokeGo/PokemonNotifier.m
+++ b/iPokeGo/PokemonNotifier.m
@@ -22,6 +22,7 @@
 @property AVAudioPlayer *pokemonAppearSound;
 @property AVAudioPlayer *pokemonFavAppearSound;
 @property BOOL incomingIsFromNewConnection;
+@property NSDictionary *localization;
 
 @end
 
@@ -55,8 +56,25 @@
         //if they've changed the server address, or if this is the first connection in a long time
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(serverChanged) name:ServerChangedNotification object:nil];
         self.incomingIsFromNewConnection = YES;
+        
+        [self loadLocalization];
     }
     return self;
+}
+
+-(void)loadLocalization {
+    NSError *error;
+    
+    NSURL *filePath = [[NSBundle mainBundle] URLForResource:@"pokemon" withExtension:@"json"];
+    
+    self.localization = [[NSDictionary alloc] init];
+    
+    NSString *stringPath = [filePath absoluteString];
+    NSData *localizationData = [NSData dataWithContentsOfURL:[NSURL URLWithString:stringPath]];
+    
+    self.localization = [NSJSONSerialization JSONObjectWithData:localizationData
+                                                        options:NSJSONReadingMutableContainers
+                                                          error:&error];
 }
 
 -(void)displayNotificationForPokemon:(Pokemon *)pokemon
@@ -65,10 +83,10 @@
     AVAudioPlayer *sound = nil;
     
     if([pokemon isFav]) {
-        message = [NSString localizedStringWithFormat:NSLocalizedString(@"[Pokemon] your favorite pokemon was added to the map!", @"The hint that a favorite Pokémon appeared on the map.") , [self.mapViewController.localization objectForKey:[NSString stringWithFormat:@"%d", pokemon.identifier]]];
+        message = [NSString localizedStringWithFormat:NSLocalizedString(@"[Pokemon] your favorite pokemon was added to the map!", @"The hint that a favorite Pokémon appeared on the map.") , [self.localization objectForKey:[NSString stringWithFormat:@"%d", pokemon.identifier]]];
         sound   = self.pokemonAppearSound;
     } else {
-        message = [NSString localizedStringWithFormat:NSLocalizedString(@"[Pokemon] was added to the map!", @"The hint that a certain Pokémon appeared on the map.") , [self.mapViewController.localization objectForKey:[NSString stringWithFormat:@"%d", pokemon.identifier]]];
+        message = [NSString localizedStringWithFormat:NSLocalizedString(@"[Pokemon] was added to the map!", @"The hint that a certain Pokémon appeared on the map.") , [self.localization objectForKey:[NSString stringWithFormat:@"%d", pokemon.identifier]]];
         sound   = self.pokemonAppearSound;
     }
     


### PR DESCRIPTION
If we’re reloading because of a server change, lets not show normal notifications on the first connect (since we’ll get a bunch).