### PR TITLE
Changes in scan location

### DIFF
--- a/iPokeGo/AppDelegate.m
+++ b/iPokeGo/AppDelegate.m
@@ -172,6 +172,7 @@ static NSTimeInterval AppDelegatServerRefreshFrequencyBackground = 20.0;
 {
     dispatch_async(AppDelegateFetcherQueue, ^{
         [self.server fetchData];
+        [self.server fetchScanLocationData];
     });
 }
 

--- a/iPokeGo/MapViewController.m
+++ b/iPokeGo/MapViewController.m
@@ -251,9 +251,6 @@ BOOL flagIsPanning              = NO;
             }
             
             [self.mapview addAnnotation:dropPin];
-            
-            [[NSUserDefaults standardUserDefaults] setObject:[NSNumber numberWithDouble:coordinate.latitude] forKey:@"radar_lat"];
-            [[NSUserDefaults standardUserDefaults] setObject:[NSNumber numberWithDouble:coordinate.longitude] forKey:@"radar_long"];
         }
         else
         {
@@ -291,8 +288,6 @@ BOOL flagIsPanning              = NO;
             
         }
         // remove scan location coordinates from user defaults
-        [[NSUserDefaults standardUserDefaults] removeObjectForKey:@"radar_lat"];
-        [[NSUserDefaults standardUserDefaults] removeObjectForKey:@"radar_long"];
         
         [self checkGPS];
     }
@@ -690,20 +685,17 @@ BOOL flagIsPanning              = NO;
 
 - (NSFetchedResultsController *)newScanLocationsFetchResultsControllersForCurrentPreferences
 {
-    if ([[[NSUserDefaults standardUserDefaults] valueForKey:@"server_type"] isEqualToString:SERVER_API_DATA_POGOM]) {
-        NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:@"ScanLocations"];
-        [request setSortDescriptors:@[[NSSortDescriptor sortDescriptorWithKey:@"identifier" ascending:YES]]];
-        request.fetchBatchSize = 50;
-        NSFetchedResultsController *frc = [[NSFetchedResultsController alloc] initWithFetchRequest:request managedObjectContext:[CoreDataPersistance sharedInstance].uiContext sectionNameKeyPath:nil cacheName:nil];
-        frc.delegate = self;
-        NSError *error = nil;
-        if (![frc performFetch:&error]) {
-            NSLog(@"Error performing fetch request for gym listing: %@", error);
-        }
-        
-        return frc;
+    NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:@"ScanLocations"];
+    [request setSortDescriptors:@[[NSSortDescriptor sortDescriptorWithKey:@"identifier" ascending:YES]]];
+    request.fetchBatchSize = 50;
+    NSFetchedResultsController *frc = [[NSFetchedResultsController alloc] initWithFetchRequest:request managedObjectContext:[CoreDataPersistance sharedInstance].uiContext sectionNameKeyPath:nil cacheName:nil];
+    frc.delegate = self;
+    NSError *error = nil;
+    if (![frc performFetch:&error]) {
+        NSLog(@"Error performing fetch request for gym listing: %@", error);
     }
-    return nil;
+    
+    return frc;
 }
 
 - (void)reloadMap {
@@ -749,28 +741,14 @@ BOOL flagIsPanning              = NO;
                 [annotations addObject:point];
             }
         }
-        if([[NSUserDefaults standardUserDefaults] objectForKey:@"radar_lat"] && [[NSUserDefaults standardUserDefaults] objectForKey:@"radar_long"] && ([[[NSUserDefaults standardUserDefaults] valueForKey:@"server_type"] isEqualToString:SERVER_API_DATA_POKEMONGOMAP])) {
-            NSLog(@"[!] Pokemon-Go Map server detected !");
-            CLLocationCoordinate2D location = CLLocationCoordinate2DMake([[NSUserDefaults standardUserDefaults] doubleForKey:@"radar_lat"],
-                                                                         [[NSUserDefaults standardUserDefaults] doubleForKey:@"radar_long"]);
-            
-            ScanAnnotation *dropPin = [[ScanAnnotation alloc] init];
-            dropPin.coordinate = location;
-            dropPin.title = NSLocalizedString(@"Scan location", @"The title of an annotation on the map to scan the location.");
-            [annotations addObject:dropPin];
-            
-            [self.radarButton setHidden:NO];
-        }
-        else
-        {
-            NSLog(@"[!] Pogom server detected !");
-            
-            if (self.locationsFetchResultController) {
-                for (ScanLocations *scanlocation in self.locationsFetchResultController.fetchedObjects) {
-                    ScanAnnotation *dropPin = [[ScanAnnotation alloc] initWithScanLocation:scanlocation];
-                    [annotations addObject:dropPin];
-                }
+        if (self.locationsFetchResultController) {
+            BOOL hasScanLocations = NO;
+            for (ScanLocations *scanlocation in self.locationsFetchResultController.fetchedObjects) {
+                ScanAnnotation *dropPin = [[ScanAnnotation alloc] initWithScanLocation:scanlocation];
+                [annotations addObject:dropPin];
+                hasScanLocations = YES;
             }
+            [self.radarButton setHidden:!hasScanLocations];
         }
         
         [self.mapview addAnnotations:annotations];

--- a/iPokeGo/MapViewController.m
+++ b/iPokeGo/MapViewController.m
@@ -845,14 +845,9 @@ BOOL flagIsPanning              = NO;
     }
 
     if(!MKMapRectIsNull(region)){
-        if (region.size.width == 0 && region.size.height == 0){
-            CLLocationCoordinate2D location = MKCoordinateForMapPoint(region.origin);
-            [self.mapview setRegion:MKCoordinateRegionMake(location, MKCoordinateSpanMake(MAP_SCALE, MAP_SCALE)) animated:YES];
-        }else{
-            MKCoordinateRegion regionMap = [self.mapview regionThatFits:MKCoordinateRegionForMapRect(region)];
-            regionMap.span = MKCoordinateSpanMake(MAP_SCALE, MAP_SCALE);
-            [self.mapview setRegion:regionMap animated:YES];
-        }
+        MKCoordinateRegion regionMap = [self.mapview regionThatFits:MKCoordinateRegionForMapRect(region)];
+        regionMap.span = MKCoordinateSpanMake(MAP_SCALE, MAP_SCALE);
+        [self.mapview setRegion:regionMap animated:YES];
     }
 }
 

--- a/iPokeGo/global.h
+++ b/iPokeGo/global.h
@@ -41,6 +41,7 @@
 #define NOTIF_FOLLOW_RED_COLOR      [UIColor colorWithRed:0.91 green:0.30 blue:0.24 alpha:1.0]
 
 #define SERVER_API_DATA_POKEMONGOMAP    @"%%server_addr%%/raw_data?pokemon=%%pokemon_display%%&pokestops=%%pokestops_display%%&gyms=%%gyms_display%%&spawnpoints=%%spawnpoints_display%%"
+#define SERVER_API_DATA_SCAN_LOCATION   @"%%server_addr%%/loc"
 #define SERVER_API_DATA_POGOM           @"%%server_addr%%/map-data?pokemon=%%pokemon_display%%&gyms=%%gyms_display%%"
 
 #define SERVER_API_LOCA_POKEMONGOMAP    @"%%server_addr%%/next_loc?lat=%%latitude%%&lon=%%longitude%%"

--- a/iPokeGo/iPokeServerSync.h
+++ b/iPokeGo/iPokeServerSync.h
@@ -12,6 +12,7 @@
 @interface iPokeServerSync : NSObject
 
 - (void)fetchData;
+- (void)fetchScanLocationData;
 - (void)setLocation:(CLLocationCoordinate2D)location;
 - (void)removeLocation:(CLLocationCoordinate2D)location;
 


### PR DESCRIPTION
Changes:

- Fetch scan location from pokemon-go map
- Removed use of radar_lat & radar_long user preferences
- Radar action show all scan notations in map (insted of fetch scan position from user defaults now it uses all scan annotations in map)