### PR TITLE
Changes in follow location + bugfix on handle set location

### DIFF
--- a/iPokeGo/AppDelegate.m
+++ b/iPokeGo/AppDelegate.m
@@ -59,7 +59,8 @@ static NSTimeInterval AppDelegatServerRefreshFrequencyBackground = 20.0;
                                @"only_notify_in_range": @"FALSE",
                                @"common_notification_range": @"100",
                                @"favorite_notification_range": @"2500",
-                               @"server_type": SERVER_API_DATA_POKEMONGOMAP};
+                               @"server_type": SERVER_API_DATA_POKEMONGOMAP,
+                               @"follow_location": @"NO"};
     [[NSUserDefaults standardUserDefaults] registerDefaults:defaults];
     
     self.server = [[iPokeServerSync alloc] init];

--- a/iPokeGo/MapViewController.m
+++ b/iPokeGo/MapViewController.m
@@ -879,11 +879,7 @@ BOOL flagIsPanning              = NO;
 
 - (CLLocation *)currentLocation
 {
-    CLLocation *baseLocation = self.mapview.userLocation.location;
-    if (!baseLocation) {
-        baseLocation = [[CLLocation alloc] initWithLatitude:[[NSUserDefaults standardUserDefaults] doubleForKey:@"radar_lat"] longitude:[[NSUserDefaults standardUserDefaults] doubleForKey:@"radar_long"]];
-    }
-    return baseLocation;
+    return self.mapview.userLocation.location;
 }
 
 -(void)showAnnotationLocalNotif:(NSNotification *)notification

--- a/iPokeGo/MapViewController.m
+++ b/iPokeGo/MapViewController.m
@@ -280,18 +280,6 @@ BOOL flagIsPanning              = NO;
         AudioServicesPlayAlertSound(kSystemSoundID_Vibrate);
         
         [self enableFollowLocation:YES];
-        
-        // remove scan annotation from map
-        for (id <MKAnnotation> annotation in self.mapview.annotations)
-        {
-            if ([annotation isKindOfClass:[ScanAnnotation class]])
-            {
-                [self.mapview removeAnnotation:annotation];
-            }
-            
-        }
-        // remove scan location coordinates from user defaults
-        
         [self checkGPS];
     }
 }

--- a/iPokeGo/iPokeServerSync.m
+++ b/iPokeGo/iPokeServerSync.m
@@ -42,28 +42,19 @@ static NSURLSession *iPokeServerSyncSharedSession;
     [request addValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
     [request setHTTPMethod:@"POST"];
     NSURLSessionDataTask *task = [[iPokeServerSync sharedSession] dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-        if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
-            NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
-            
-            if (httpResponse.statusCode != 200 && httpResponse.statusCode != 204) {
-                NSLog(@"Server returned non 200 or 204 code: %@", @(httpResponse.statusCode));
-                if([[[NSUserDefaults standardUserDefaults] valueForKey:@"server_type"] isEqualToString:SERVER_API_DATA_POGOM])
-                    NSLog(@"Position changed !");
-                return;
-            }
-        }
-        
         if (error) {
             NSLog(@"Error reading server's data: %@", error);
             return;
         }
         
-        if([[[NSUserDefaults standardUserDefaults] valueForKey:@"server_type"] isEqualToString:SERVER_API_DATA_POKEMONGOMAP])
-        {
-            NSString *dataStr = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-            if([dataStr isEqualToString:@"ok"]) {
+        if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
+            NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
+            
+            if (httpResponse.statusCode == 200 || httpResponse.statusCode == 204) {
                 NSLog(@"Position changed !");
-            } else {
+            }else{
+                NSLog(@"Server returned non 200 or 204 code: %@", @(httpResponse.statusCode));
+                NSString *dataStr = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
                 NSLog(@"Error changing pinned location, server responded: %@", dataStr);
             }
         }


### PR DESCRIPTION
Changes:

- Follow location state saved in user preferences
- Delete scan annotations not needed when follow location is enabled. Now scan location is fetched from server.
- Fixed bug: handling server response after change scan location.
- Removed last use of radar_lat & radar_long users preferences